### PR TITLE
Fix `middleware/index.js` to satify eslint `arrow-body-style`

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
     "react-router-redux": "4.0.8",
-    "react-scripts": "3.4.1",
+    "react-scripts": "5.0.1",
     "redux": "4.0.5",
     "redux-actions": "2.6.5",
     "redux-logger": "3.0.6",

--- a/ui/src/middleware/index.js
+++ b/ui/src/middleware/index.js
@@ -3,10 +3,10 @@ import { isFSA } from 'flux-standard-action'
 /**
  * FSA compliant middlware which handles if the payload of an action is a function.
  */
-const thunkMiddleware = (extraArg) => {
-  return ({ dispatch, getState }) => {
-    return (next)=> {
-      return (action) => {
+const thunkMiddleware = (extraArg) =>
+  ({ dispatch, getState }) =>
+    (next)=>
+      (action) => {
         if (isFSA(action) && typeof action.payload === 'function') {
           return next(
             {
@@ -18,7 +18,4 @@ const thunkMiddleware = (extraArg) => {
           return next(action)
         }
       }
-    }
-  }
-}
 export { thunkMiddleware }


### PR DESCRIPTION
I encountered an issue with nodejs 18 and react-scripts 5.0.1 where eslint complained about arrow-body-style